### PR TITLE
Add admin respond cross cluster task completed API

### DIFF
--- a/thrift/admin.thrift
+++ b/thrift/admin.thrift
@@ -217,6 +217,16 @@ service AdminService {
     )
 
   /**
+  * RespondCrossClusterTasksCompleted responds the result of processing cross cluster tasks
+  **/
+  shared.RespondCrossClusterTasksCompletedResponse RespondCrossClusterTasksCompleted(1: shared.RespondCrossClusterTasksCompletedRequest request) 
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.ServiceBusyError serviceBusyError,
+    )
+
+  /**
   * GetDynamicConfig returns values associated with a specified dynamic config parameter.
   **/
   GetDynamicConfigResponse GetDynamicConfig(1: GetDynamicConfigRequest request)


### PR DESCRIPTION
When the target cluster history service needs to respond cross-cluster task results back, it can't talk directly to the source cluster's history host and must call the admin client first to redirect the call.

Server side change will be send out after https://github.com/uber/cadence/pull/4554 is landed.