### PR TITLE
Persist domainID instead of domainName for childExecutionInfo

### DIFF
--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -183,7 +183,8 @@ struct ChildExecutionInfo {
   24: optional binary startedEvent
   26: optional string startedEventEncoding
   28: optional string createRequestID
-  30: optional string domainName
+  29: optional string domainID
+  30: optional string domainName // deprecated
   32: optional string workflowTypeName
   35: optional i32 parentClosePolicy
 }


### PR DESCRIPTION
Similar to activityInfo, domainID is easier to use when actually processing child workflow related tasks.
Also if in the future we decided to allow delete domain and re-create one with the same name, domainName can't tell which one is which. But since domainID is always unique, we can tell.