### PR TITLE
added domainId to RegisterDomainRequest

### DIFF
--- a/go/proto/api/v1/service_domain.pb.go
+++ b/go/proto/api/v1/service_domain.pb.go
@@ -59,6 +59,7 @@ type RegisterDomainRequest struct {
 	HistoryArchivalUri               string                             `protobuf:"bytes,11,opt,name=history_archival_uri,json=historyArchivalUri,proto3" json:"history_archival_uri,omitempty"`
 	VisibilityArchivalStatus         ArchivalStatus                     `protobuf:"varint,12,opt,name=visibility_archival_status,json=visibilityArchivalStatus,proto3,enum=uber.cadence.api.v1.ArchivalStatus" json:"visibility_archival_status,omitempty"`
 	VisibilityArchivalUri            string                             `protobuf:"bytes,13,opt,name=visibility_archival_uri,json=visibilityArchivalUri,proto3" json:"visibility_archival_uri,omitempty"`
+	DomainID                         string                             `protobuf:"bytes,14,opt,name=domain_id,json=domainId,proto3" json:"domain_id,omitempty"`
 	XXX_NoUnkeyedLiteral             struct{}                           `json:"-"`
 	XXX_unrecognized                 []byte                             `json:"-"`
 	XXX_sizecache                    int32                              `json:"-"`

--- a/proto/uber/cadence/api/v1/service_domain.proto
+++ b/proto/uber/cadence/api/v1/service_domain.proto
@@ -67,6 +67,7 @@ message RegisterDomainRequest {
   string history_archival_uri = 11;
   ArchivalStatus visibility_archival_status = 12;
   string visibility_archival_uri = 13;
+  string domain_id = 14;
 }
 
 message RegisterDomainResponse {

--- a/proto/uber/cadence/api/v1/service_domain.proto
+++ b/proto/uber/cadence/api/v1/service_domain.proto
@@ -54,6 +54,9 @@ service DomainAPI {
 }
 
 message RegisterDomainRequest {
+  // domain_id is optional. A random UUID is generated if not set. 
+  // It can be set to a custom UUID as long as it doesn't collide with existing domain ids
+  // If unsure leave this empty.
   string security_token = 1;
   string name = 2;
   string description = 3;

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1095,6 +1095,7 @@ struct RegisterDomainRequest {
   140: optional string historyArchivalURI
   150: optional ArchivalStatus visibilityArchivalStatus
   160: optional string visibilityArchivalURI
+  170: optional string domainId
 }
 
 struct ListDomainsRequest {


### PR DESCRIPTION
### Summary
Towards [Issue](https://github.com/uber/cadence/issues/5350)

### Type of Change
- [ ] Add new API(s)
- [ ] Add new data type(s)
- [x] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [ ] Other (please provide detailed description)

### Data Effect
- [ ] Does it change the data stored in database?

### Detailed Description
Added field domainId in the requests to support the functionality of using user provided domain id at the time of domain creation.

### Impact Analysis
- **Backward Compatibility**: [Analysis of backward compatibility] Backwards compatible
- **Forward Compatibility**: [Analysis of forward compatibility]

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?] Yes
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?] Yes
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

### Rollout Plan
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
