### PR TITLE
Introduce data types for queue v2

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -2034,3 +2034,26 @@ struct AutoConfigHint {
   10: optional bool enableAutoConfig
   20: optional i64 pollerWaitTimeInMs
 }
+
+struct QueueState {
+  10: optional map<i64, VirtualQueueState> virtualQueueStates
+  20: optional TaskKey exclusiveMaxReadLevel
+}
+
+struct VirtualQueueState {
+  10: optional list<VirtualSliceState> virtualSliceStates
+}
+
+struct VirtualSliceState {
+  10: optional TaskRange taskRange
+}
+
+struct TaskRange {
+  10: optional TaskKey inclusiveMin
+  20: optional TaskKey exclusiveMax
+}
+
+struct TaskKey {
+  10: optional i64 scheduledTimeNano
+  20: optional i64 taskID
+}

--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -42,6 +42,7 @@ struct ShardInfo {
   56: optional string timerProcessingQueueStatesEncoding
   60: optional binary crossClusterProcessingQueueStates
   61: optional string crossClusterProcessingQueueStatesEncoding
+  64: optional map<i32, shared.QueueState> queueStates
 }
 
 struct DomainInfo {


### PR DESCRIPTION
### Summary
Introduce queue states to shardInfo.

### Type of Change
- [ ] Add new API(s)
- [x] Add new data type(s)
- [x] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [ ] Other (please provide detailed description)

### Data Effect
- [x] Does it change the data stored in database?

### Detailed Description
Define new data types representing the state of new version of history queue and store the new queue state in shard info blob.

### Impact Analysis
- **Backward Compatibility**: Yes.
- **Forward Compatibility**: Yes.

### Testing Plan
- **Unit Tests**: Will have unit tests covered once merged into server repo.
- **Persistence Tests**: CRUD of the new data will be covered by persistence test.
- **Integration Tests**: Integration tests will be introduced when we implement the history queuev2 framework.
- **Compatibility Tests**: it's compatible
 
### Rollout Plan
- What is the rollout plan? As usual.
- Does the order of deployment matter? No.
- Is it safe to rollback? Does the order of rollback matter? It's safe to rollback right now, but once we switch to queuev2 we cannot roll it back without rolling back queue framework from v2 to v1.
- Is there a kill switch to mitigate the impact immediately? No.
