### PR TITLE
[domain-deletion]Add delete domain operation in replicator

### DIFF
--- a/thrift/replicator.thrift
+++ b/thrift/replicator.thrift
@@ -35,6 +35,7 @@ enum ReplicationTaskType {
 enum DomainOperation {
   Create
   Update
+  Delete
 }
 
 struct DomainTaskAttributes {
@@ -42,7 +43,7 @@ struct DomainTaskAttributes {
   10: optional string id
   20: optional shared.DomainInfo info
   30: optional shared.DomainConfiguration config
-  40: optional shared.DomainReplicationConfiguration replicationConfig
+  40: optional shared.DomainReplicationConfiguration replicationConf ig
   50: optional i64 (js.type = "Long") configVersion
   60: optional i64 (js.type = "Long") failoverVersion
   70: optional i64 (js.type = "Long") previousFailoverVersion


### PR DESCRIPTION
### Summary
[Brief summary of the change, including the rationale and intended effect]
This PR adds a new data type to the replicator: DOMAIN_OPERATION_DELETE. This will allow us to delete global domains in a passive cluster.

### Type of Change
- [ ] Add new API(s)
- [x] Add new data type(s)
- [ ] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [ ] Other (please provide detailed description)

### Data Effect
- [ ] Does it change the data stored in database? No

### Detailed Description
[In-depth description of the changes made to the IDL, specifying new fields, removed fields, or modified data structures]
DOMAIN_OPERATION_DELETE data type was added to the replicator. The existing data types are:

DOMAIN_OPERATION_CREATE - used to sync domain creation
DOMAIN_OPERATION_UPDATE - replicates any domain updates in the passive cluster

### Impact Analysis
- **Backward Compatibility**: [Analysis of backward compatibility] Yes, as it is a new data type
- **Forward Compatibility**: [Analysis of forward compatibility] Yes, as it is a new data type

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?] -
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?] - 
- **Integration Tests**: [Do we have integration test covering the change?] - 
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?] -

### Rollout Plan
- What is the rollout plan?  Rollout to the dev environments first, then deploy to production envs in waves
- Does the order of deployment matter? No
- Is it safe to rollback? Does the order of rollback matter? Yes
- Is there a kill switch to mitigate the impact immediately? No
