### PR TITLE
Change active cluster policy to blob in sqlblobs

### DIFF
--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -149,7 +149,8 @@ struct WorkflowExecutionInfo {
   130: optional binary checksum
   132: optional string checksumEncoding
   134: optional shared.CronOverlapPolicy cronOverlapPolicy
-  136: optional shared.ActiveClusterSelectionPolicy activeClusterSelectionPolicy
+  137: optional binary activeClusterSelectionPolicy
+  138: optional string activeClusterSelectionPolicyEncoding
 }
 
 struct ActivityInfo {


### PR DESCRIPTION
### Summary
[Brief summary of the change, including the rationale and intended effect]

### Type of Change
- [ ] Add new API(s)
- [ ] Add new data type(s)
- [x] Add new field(s) to existing data type
- [x] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [ ] Other (please provide detailed description)

### Data Effect
- [x] Does it change the data stored in database?

### Detailed Description
[In-depth description of the changes made to the IDL, specifying new fields, removed fields, or modified data structures]
The new `activeClusterSelectionPolicy` field was defined as a typed field in sqlblobs however while doing the integration I noticed the data arrives to the corresponding sql persistence layer already serialized. So changing the type to blob. 
Not used anywhere yet so it's ok to remove/add new field.

### Impact Analysis
- **Backward Compatibility**: [Analysis of backward compatibility]
- **Forward Compatibility**: [Analysis of forward compatibility]

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

### Rollout Plan
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
