### PR TITLE
Change from required to optional for EntityNotExistsError

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -51,7 +51,7 @@ exception EntityNotExistsError {
   2: optional string currentCluster
   3: optional string activeCluster
   // activeClusters is a list of active clusters for active-active domain
-  4: required list<string> activeClusters
+  4: optional list<string> activeClusters
 }
 
 exception ServiceBusyError {


### PR DESCRIPTION
### Summary

ActiveClusters field should not be required

### Type of Change
- [] Add new API(s)
- [ ] Add new data type(s)
- [ ] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [X] Other (please provide detailed description)

### Data Effect
- [ ] Does it change the data stored in database? No

### Detailed Description
[In-depth description of the changes made to the IDL, specifying new fields, removed fields, or modified data structures]
Modified the field from required to optional. This is NOT a breaking change since the active-active feature is still in development

### Impact Analysis
- **Backward Compatibility**: [Analysis of backward compatibility] Yes
- **Forward Compatibility**: [Analysis of forward compatibility] Yes

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

### Rollout Plan
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
