### PR TITLE
Revert "change from required to optional for EntityNotExistsError (#213)

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -51,7 +51,7 @@ exception EntityNotExistsError {
   2: optional string currentCluster
   3: optional string activeCluster
   // activeClusters is a list of active clusters for active-active domain
-  4: optional list<string> activeClusters
+  4: required list<string> activeClusters
 }
 
 exception ServiceBusyError {


### PR DESCRIPTION
This is a breaking change and we should revert it. It's ok to have this field required. 

This reverts commit f08e66d311941fb87f622c8b54fd5c64205a192d.

### Summary
[Brief summary of the change, including the rationale and intended effect]

### Type of Change
- [x] Add new API(s)
- [ ] Add new data type(s)
- [ ] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [ ] Other (please provide detailed description)

### Data Effect
- [ ] Does it change the data stored in database?

### Detailed Description
[In-depth description of the changes made to the IDL, specifying new fields, removed fields, or modified data structures]

### Impact Analysis
- **Backward Compatibility**: [Analysis of backward compatibility]
- **Forward Compatibility**: [Analysis of forward compatibility]

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

### Rollout Plan
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
