### PR TITLE
Update protobuf version to 29.1 and regenerate all files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ proto-lint: $(PROTO_FILES) $(BIN)/$(BUF_VERSION_BIN)
 # https://www.grpc.io/docs/languages/go/quickstart/
 # protoc-gen-gogofast (yarpc) are versioned via tools.go + go.mod (built above) and will be rebuilt as needed.
 # changing PROTOC_VERSION will automatically download and use the specified version
-PROTOC_VERSION = 3.14.0
-PROTOC_URL = https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-$(subst Darwin,osx,$(OS))-$(ARCH).zip
+PROTOC_VERSION = 29.5
+PROTOC_URL = https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-$(subst Darwin,osx,$(OS))-$(subst arm64,aarch_64,$(ARCH)).zip
 # the zip contains an /include folder that we need to use to learn the well-known types
 PROTOC_UNZIP_DIR = $(BIN)/protoc-$(PROTOC_VERSION)-zip
 # use PROTOC_VERSION_BIN as a bin prerequisite, not "protoc", so the correct version will be used.

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ proto-lint: $(PROTO_FILES) $(BIN)/$(BUF_VERSION_BIN)
 # protoc-gen-gogofast (yarpc) are versioned via tools.go + go.mod (built above) and will be rebuilt as needed.
 # changing PROTOC_VERSION will automatically download and use the specified version
 PROTOC_VERSION = 29.5
-PROTOC_URL = https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-$(subst Darwin,osx,$(OS))-$(subst arm64,aarch_64,$(ARCH)).zip
+# Normalize architecture names for protobuf releases
+PROTOC_ARCH = $(subst arm64,aarch_64,$(subst aarch64,aarch_64,$(ARCH)))
+PROTOC_URL = https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-$(subst Darwin,osx,$(OS))-$(PROTOC_ARCH).zip
 # the zip contains an /include folder that we need to use to learn the well-known types
 PROTOC_UNZIP_DIR = $(BIN)/protoc-$(PROTOC_VERSION)-zip
 # use PROTOC_VERSION_BIN as a bin prerequisite, not "protoc", so the correct version will be used.

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ proto-lint: $(PROTO_FILES) $(BIN)/$(BUF_VERSION_BIN)
 # https://www.grpc.io/docs/languages/go/quickstart/
 # protoc-gen-gogofast (yarpc) are versioned via tools.go + go.mod (built above) and will be rebuilt as needed.
 # changing PROTOC_VERSION will automatically download and use the specified version
-PROTOC_VERSION = 29.5
+PROTOC_VERSION = 29.1
 # Normalize architecture names for protobuf releases
 PROTOC_ARCH = $(subst arm64,aarch_64,$(subst aarch64,aarch_64,$(ARCH)))
 PROTOC_URL = https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-$(subst Darwin,osx,$(OS))-$(PROTOC_ARCH).zip


### PR DESCRIPTION
### Summary
[Brief summary of the change, including the rationale and intended effect]
Updated the protobuf compiler version from 3.14.0 to 29.1. We also regenerate all Go protobuf files with the updated compiler version but no file changes observed, maintaining backward compatibility while providing access to newer protobuf capabilities.


### Type of Change
- [ ] Add new API(s)
- [ ] Add new data type(s)
- [ ] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [X] Other (please provide detailed description)

### Data Effect
- [ ] Does it change the data stored in database?
No

### Detailed Description
[In-depth description of the changes made to the IDL, specifying new fields, removed fields, or modified data structures]
Changes Made:
Updated PROTOC_VERSION in Makefile from 3.14.0 to 29.1
Fixed URL format for newer protobuf versions to use aarch_64 instead of arm64 for ARM64 architecture
Regenerated all protobuf Go files in both go/proto/api/v1/ and go/proto/admin/v1/ directories

Version Mapping:
- Protoc Version: 29.1
- Python Equivalent: 5.29.1
- Java Equivalent: 3.29.1

### Impact Analysis
- **Backward Compatibility**: [Analysis of backward compatibility]
Compatible since no generated files changed observed.
- **Forward Compatibility**: [Analysis of forward compatibility]
Compatible since no generated files changed observed.

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

### Rollout Plan
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
