### PR TITLE
Add support for storing the TaskListKind on ActivityInfo

### DIFF
--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -174,6 +174,7 @@ struct ActivityInfo {
   44: optional i32 timerTaskStatus
   46: optional i32 attempt
   48: optional string taskList
+  49: optional shared.TaskListKind taskListKind
   50: optional string startedIdentity
   52: optional bool hasRetryPolicy
   54: optional i32 retryInitialIntervalSeconds


### PR DESCRIPTION
This was missed in https://github.com/cadence-workflow/cadence-idl/pull/209 and is equivalent to what it stored on the WorkflowExecutionInfo. Individual activities may be dispatched to a TaskList of a different kind than the Workflow itself or even other activities.

### Summary

Support TaskListKinds specified for individual Activities.

### Type of Change
- [ ] Add new API(s)
- [ ] Add new data type(s)
- [x] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [ ] Other (please provide detailed description)

### Data Effect
- [x] Does it change the data stored in database?

### Detailed Description
[In-depth description of the changes made to the IDL, specifying new fields, removed fields, or modified data structures]

### Impact Analysis
- **Backward Compatibility**: Any existing rows will be treated as if they have NORMAL, which is the default value for new rows as well.
- **Forward Compatibility**: Any new TaskListKind will be supported

### Testing Plan
- **Unit Tests**: Will be added
- **Persistence Tests**: Will be added
- **Integration Tests**: Will be added
- **Compatibility Tests**:  YEs

### Rollout Plan
- What is the rollout plan? Roll out fully on the server before any usage from clients
- Does the order of deployment matter? No
- Is it safe to rollback? Does the order of rollback matter? Safe to rollback
- Is there a kill switch to mitigate the impact immediately? Rollback
