### PR TITLE
chore(active-active): add thrift deprecated annotation to activeclusterselectionpolicy

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -2220,10 +2220,10 @@ struct TaskKey {
 struct ActiveClusterSelectionPolicy {
   1: optional ClusterAttribute clusterAttribute
 
-  10: optional ActiveClusterSelectionStrategy strategy // todo (david.porter) remove these as they're not used anymore
-  20: optional string stickyRegion                     // todo (david.porter) remove these as they're not used anymore
-  30: optional string externalEntityType               // todo (david.porter) remove these as they're not used anymore
-  40: optional string externalEntityKey                // todo (david.porter) remove these as they're not used anymore
+  10: optional ActiveClusterSelectionStrategy strategy (deprecated = "unused active-active field")
+  20: optional string stickyRegion                     (deprecated = "unused active-active field")
+  30: optional string externalEntityType               (deprecated = "unused active-active field")
+  40: optional string externalEntityKey                (deprecated = "unused active-active field")
 }
 
 // ClusterAttribute is used for subdividing workflows in a domain into their active
@@ -2265,12 +2265,11 @@ struct PaginationOptions {
   20: optional binary nextPageToken
 }
 
-// todo (david.porter) Remove this, as it's no longer needed
 // with the active/active configuration we have
 enum ActiveClusterSelectionStrategy {
   REGION_STICKY,
   EXTERNAL_ENTITY,
-}
+} (deprecated = "unused active-active field")
 
 enum PredicateType {
   Universal,


### PR DESCRIPTION
### Summary
[Brief summary of the change, including the rationale and intended effect]
add thrift annotation so different code generators can act on deprecated field. This is mostly needed by java SDK. 

### Type of Change
- [] Add new API(s)
- [ ] Add new data type(s)
- [ ] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [X] Other (please provide detailed description)
add thrift annotation

### Data Effect
- [ ] Does it change the data stored in database? 
No

### Detailed Description
[In-depth description of the changes made to the IDL, specifying new fields, removed fields, or modified data structures]
annotation only change


### Impact Analysis
- **Backward Compatibility**: [Analysis of backward compatibility] Yes
- **Forward Compatibility**: [Analysis of forward compatibility] Yes

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

No change in generated go code. 

### Rollout Plan
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
